### PR TITLE
fix defines with string values that use other defined constants

### DIFF
--- a/src/plugins/messagearchiver/messagearchiver.cpp
+++ b/src/plugins/messagearchiver/messagearchiver.cpp
@@ -32,8 +32,8 @@
 #define ARCHIVE_REQUEST_TIMEOUT    30000
 
 #define SHC_MESSAGE_BODY           "/message/body"
-#define SHC_PREFS                  "/iq[@type='set']/pref[@xmlns="NS_ARCHIVE"]"
-#define SHC_PREFS_OLD              "/iq[@type='set']/pref[@xmlns="NS_ARCHIVE_OLD"]"
+#define SHC_PREFS                  "/iq[@type='set']/pref[@xmlns=" NS_ARCHIVE "]"
+#define SHC_PREFS_OLD              "/iq[@type='set']/pref[@xmlns=" NS_ARCHIVE_OLD "]"
 
 #define ADR_STREAM_JID             Action::DR_StreamJid
 #define ADR_CONTACT_JID            Action::DR_Parametr1

--- a/src/plugins/privacylists/privacylists.cpp
+++ b/src/plugins/privacylists/privacylists.cpp
@@ -11,8 +11,8 @@
 #include <definitions/stanzahandlerorders.h>
 #include <utils/logger.h>
 
-#define SHC_PRIVACY         "/iq[@type='set']/query[@xmlns='"NS_JABBER_PRIVACY"']"
-#define SHC_ROSTER          "/iq/query[@xmlns='"NS_JABBER_ROSTER"']"
+#define SHC_PRIVACY         "/iq[@type='set']/query[@xmlns='" NS_JABBER_PRIVACY "']"
+#define SHC_ROSTER          "/iq/query[@xmlns='" NS_JABBER_ROSTER "']"
 
 #define PRIVACY_TIMEOUT     60000
 #define AUTO_LISTS_TIMEOUT  2000

--- a/src/plugins/sessionnegotiation/sessionnegotiation.cpp
+++ b/src/plugins/sessionnegotiation/sessionnegotiation.cpp
@@ -19,7 +19,7 @@
 #include <utils/message.h>
 #include <utils/logger.h>
 
-#define SHC_STANZA_SESSION            "/message/feature[@xmlns='"NS_FEATURENEG"']"
+#define SHC_STANZA_SESSION            "/message/feature[@xmlns='" NS_FEATURENEG "']"
 
 #define SFP_DISCLOSURE                "disclosure"
 #define SFP_MULTISESSION              "multisession"

--- a/src/plugins/simplemessagestyle/simplemessagestyle.cpp
+++ b/src/plugins/simplemessagestyle/simplemessagestyle.cpp
@@ -18,7 +18,7 @@
 #define CONSECUTIVE_TIMEOUT                 2*60
 
 #define SCROLL_TIMEOUT                      100
-#define SHARED_STYLE_PATH                   RESOURCES_DIR"/"RSR_STORAGE_SIMPLEMESSAGESTYLES"/"FILE_STORAGE_SHARED_DIR
+#define SHARED_STYLE_PATH                   RESOURCES_DIR "/" RSR_STORAGE_SIMPLEMESSAGESTYLES "/" FILE_STORAGE_SHARED_DIR
 
 static const char *SenderColors[] =  {
 	"blue", "blueviolet", "brown", "cadetblue", "chocolate", "coral", "cornflowerblue", "crimson",


### PR DESCRIPTION
gcc 6.1.1 complains about `warning: invalid suffix on literal; C++11 requires a space between literal and string macro` and sometimes even fail. So I added spaces around literals to make him happy.
