### PR TITLE
Использование radiobutton-ов в выпадающих меню

### DIFF
--- a/src/plugins/chatstates/statewidget.cpp
+++ b/src/plugins/chatstates/statewidget.cpp
@@ -16,27 +16,29 @@ StateWidget::StateWidget(IChatStates *AChatStates, IMessageWindow *AWindow, QWid
 	FMultiWindow = qobject_cast<IMultiUserChatWindow *>(AWindow->instance());
 
 	FMenu = new Menu(this);
+	QActionGroup *actionGroup = new QActionGroup(FMenu);
+	connect(actionGroup,SIGNAL(triggered(QAction*)),SLOT(onStatusActionTriggered(QAction*)));
 	setMenu(FMenu);
 
 	Action *permitDefault = new Action(FMenu);
 	permitDefault->setCheckable(true);
 	permitDefault->setText(tr("Default"));
 	permitDefault->setData(ADR_PERMIT_STATUS, IChatStates::StatusDefault);
-	connect(permitDefault,SIGNAL(triggered(bool)),SLOT(onStatusActionTriggered(bool)));
+	permitDefault->setActionGroup(actionGroup);
 	FMenu->addAction(permitDefault);
 
 	Action *permitEnable = new Action(FMenu);
 	permitEnable->setCheckable(true);
 	permitEnable->setText(tr("Always send my chat activity"));
 	permitEnable->setData(ADR_PERMIT_STATUS, IChatStates::StatusEnable);
-	connect(permitEnable,SIGNAL(triggered(bool)),SLOT(onStatusActionTriggered(bool)));
+	permitEnable->setActionGroup(actionGroup);
 	FMenu->addAction(permitEnable);
 
 	Action *permitDisable = new Action(FMenu);
 	permitDisable->setCheckable(true);
 	permitDisable->setText(tr("Never send my chat activity"));
 	permitDisable->setData(ADR_PERMIT_STATUS, IChatStates::StatusDisable);
-	connect(permitDisable,SIGNAL(triggered(bool)),SLOT(onStatusActionTriggered(bool)));
+	permitDisable->setActionGroup(actionGroup);
 	FMenu->addAction(permitDisable);
 
 	connect(FChatStates->instance(),SIGNAL(permitStatusChanged(const Jid &, int)),SLOT(onPermitStatusChanged(const Jid &, int)));
@@ -61,7 +63,7 @@ StateWidget::~StateWidget()
 
 }
 
-void StateWidget::onStatusActionTriggered(bool)
+void StateWidget::onStatusActionTriggered(QAction*)
 {
 	Action *action = qobject_cast<Action *>(sender());
 	if (action)

--- a/src/plugins/chatstates/statewidget.h
+++ b/src/plugins/chatstates/statewidget.h
@@ -15,7 +15,7 @@ public:
 	StateWidget(IChatStates *AChatStates, IMessageWindow *AWindow, QWidget *AParent);
 	~StateWidget();
 protected slots:
-	void onStatusActionTriggered(bool);
+	void onStatusActionTriggered(QAction*);
 	void onPermitStatusChanged(const Jid &AContactJid, int AStatus);
 	void onUserChatStateChanged(const Jid &AStreamJid, const Jid &AContactJid, int AState);
 	void onUserRoomStateChanged(const Jid &AStreamJid, const Jid &AUserJid, int AState);

--- a/src/plugins/messagearchiver/chatwindowmenu.cpp
+++ b/src/plugins/messagearchiver/chatwindowmenu.cpp
@@ -230,6 +230,7 @@ void ChatWindowMenu::onActionTriggered(bool)
 			if (FSessionNegotiation)
 				FSessionNegotiation->terminateSession(streamJid(),contactJid());
 		}
+		updateMenu();
 	}
 }
 

--- a/src/plugins/messagearchiver/chatwindowmenu.cpp
+++ b/src/plugins/messagearchiver/chatwindowmenu.cpp
@@ -94,25 +94,33 @@ void ChatWindowMenu::restoreSessionPrefs(const Jid &AContactJid)
 
 void ChatWindowMenu::createActions()
 {
+	QActionGroup *archivingGroup = new QActionGroup(this);
+
 	FEnableArchiving = new Action(this);
 	FEnableArchiving->setCheckable(true);
 	FEnableArchiving->setText(tr("Enable Message Archiving"));
+	EnableArchiving->setActionGroup(archivingGroup);
 	connect(FEnableArchiving,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FEnableArchiving,AG_DEFAULT,false);
 
 	FDisableArchiving = new Action(this);
 	FDisableArchiving->setCheckable(true);
 	FDisableArchiving->setText(tr("Disable Message Archiving"));
+	FDisableArchiving->setActionGroup(archivingGroup);
 	connect(FDisableArchiving,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FDisableArchiving,AG_DEFAULT,false);
 
+	QActionGroup *OTRGroup = new QActionGroup(this);
+
 	FStartOTRSession = new Action(this);
 	FStartOTRSession->setText(tr("Start Off-The-Record Session"));
+	FStartOTRSession->setActionGroup(OTRGroup);
 	connect(FStartOTRSession,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FStartOTRSession,AG_DEFAULT+100,false);
 
 	FStopOTRSession = new Action(this);
 	FStopOTRSession->setText(tr("Terminate Off-The-Record Session"));
+	FStopOTRSession->setActionGroup(OTRGroup);
 	connect(FStopOTRSession,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FStopOTRSession,AG_DEFAULT+100,false);
 }
@@ -222,7 +230,6 @@ void ChatWindowMenu::onActionTriggered(bool)
 			if (FSessionNegotiation)
 				FSessionNegotiation->terminateSession(streamJid(),contactJid());
 		}
-		updateMenu();
 	}
 }
 

--- a/src/plugins/messagearchiver/chatwindowmenu.cpp
+++ b/src/plugins/messagearchiver/chatwindowmenu.cpp
@@ -99,7 +99,7 @@ void ChatWindowMenu::createActions()
 	FEnableArchiving = new Action(this);
 	FEnableArchiving->setCheckable(true);
 	FEnableArchiving->setText(tr("Enable Message Archiving"));
-	EnableArchiving->setActionGroup(archivingGroup);
+	FEnableArchiving->setActionGroup(archivingGroup);
 	connect(FEnableArchiving,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FEnableArchiving,AG_DEFAULT,false);
 

--- a/src/plugins/messagearchiver/chatwindowmenu.cpp
+++ b/src/plugins/messagearchiver/chatwindowmenu.cpp
@@ -110,17 +110,13 @@ void ChatWindowMenu::createActions()
 	connect(FDisableArchiving,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FDisableArchiving,AG_DEFAULT,false);
 
-	QActionGroup *OTRGroup = new QActionGroup(this);
-
 	FStartOTRSession = new Action(this);
 	FStartOTRSession->setText(tr("Start Off-The-Record Session"));
-	FStartOTRSession->setActionGroup(OTRGroup);
 	connect(FStartOTRSession,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FStartOTRSession,AG_DEFAULT+100,false);
 
 	FStopOTRSession = new Action(this);
 	FStopOTRSession->setText(tr("Terminate Off-The-Record Session"));
-	FStopOTRSession->setActionGroup(OTRGroup);
 	connect(FStopOTRSession,SIGNAL(triggered(bool)),SLOT(onActionTriggered(bool)));
 	addAction(FStopOTRSession,AG_DEFAULT+100,false);
 }


### PR DESCRIPTION
Использование radiobutton-ов в выпадающих меню: история, отправка информации об активности в чате.