### PR TITLE
Should use language name instead of locale name

### DIFF
--- a/src/plugins/xmppstreams/xmppstream.cpp
+++ b/src/plugins/xmppstreams/xmppstream.cpp
@@ -427,7 +427,7 @@ void XmppStream::startStream()
 	stream.setAttribute("to", FStreamJid.domain());
 	stream.setAttribute("xmlns", NS_JABBER_CLIENT);
 	stream.setAttribute("xmlns:xml", NS_XML);
-	stream.setAttribute("xml:lang", !FDefLang.isEmpty() ? FDefLang : QLocale().name());
+	stream.setAttribute("xml:lang", !FDefLang.isEmpty() ? FDefLang : QLocale::languageToString(QLocale().language()));
 
 	setStreamState(SS_INITIALIZE);
 	if (!processStanzaHandlers(stream,true))


### PR DESCRIPTION
Если попробовать зайти в `ejabberd@conference.process-one.net`, то увидим ошибку в логах сервера:
> Bad value of attribute 'xml:lang' in tag <presence/> qualified by namespace 'jabber:server'