### PR TITLE
Выровнять поле поиска контактов с полем темой сообщения

### DIFF
--- a/src/interfaces/imessagewidgets.h
+++ b/src/interfaces/imessagewidgets.h
@@ -169,6 +169,7 @@ public:
 	virtual void setGroupSelection(const Jid &AStreamJid, const QString &AGroup, bool ASelected) =0;
 	virtual void setAddressSelection(const Jid &AStreamJid, const Jid &AContactJid, bool ASelected) =0;
 	virtual void clearSelection() =0;
+	virtual QVBoxLayout *getVBoxWidget() =0;
 protected:
 	virtual void availStreamsChanged() =0;
 	virtual void addressSelectionChanged() =0;

--- a/src/plugins/messagewidgets/editwidget.ui
+++ b/src/plugins/messagewidgets/editwidget.ui
@@ -12,9 +12,18 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
-    <number>3</number>
+    <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>

--- a/src/plugins/messagewidgets/normalwindow.cpp
+++ b/src/plugins/messagewidgets/normalwindow.cpp
@@ -72,8 +72,9 @@ NormalWindow::NormalWindow(IMessageWidgets *AMessageWidgets, const Jid& AStreamJ
 	Menu *menu = new Menu(ui.tlbReceivers);
 	ui.tlbReceivers->setMenu(menu);
 	connect(menu,SIGNAL(aboutToShow()),SLOT(onSelectReceiversMenuAboutToShow()));
-
 	IconStorage::staticStorage(RSR_STORAGE_MENUICONS)->insertAutoIcon(ui.tlbReceivers,MNI_MESSAGEWIDGETS_SELECT);
+
+	FReceiversWidget->getVBoxWidget()->insertWidget(1, ui.hboxReceiversW);
 
 	connect(Shortcuts::instance(),SIGNAL(shortcutActivated(const QString, QWidget *)),SLOT(onShortcutActivated(const QString, QWidget *)));
 

--- a/src/plugins/messagewidgets/normalwindow.cpp
+++ b/src/plugins/messagewidgets/normalwindow.cpp
@@ -74,6 +74,7 @@ NormalWindow::NormalWindow(IMessageWidgets *AMessageWidgets, const Jid& AStreamJ
 	connect(menu,SIGNAL(aboutToShow()),SLOT(onSelectReceiversMenuAboutToShow()));
 	IconStorage::staticStorage(RSR_STORAGE_MENUICONS)->insertAutoIcon(ui.tlbReceivers,MNI_MESSAGEWIDGETS_SELECT);
 
+	ui.sprReceivers->setCollapsible(ui.sprReceivers->indexOf(ui.layoutWidget), false);
 	FReceiversWidget->getVBoxWidget()->insertWidget(1, ui.hboxReceiversW);
 
 	connect(Shortcuts::instance(),SIGNAL(shortcutActivated(const QString, QWidget *)),SLOT(onShortcutActivated(const QString, QWidget *)));

--- a/src/plugins/messagewidgets/normalwindow.ui
+++ b/src/plugins/messagewidgets/normalwindow.ui
@@ -21,7 +21,16 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout_3">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>5</number>
+    </property>
+    <property name="topMargin">
+     <number>5</number>
+    </property>
+    <property name="rightMargin">
+     <number>5</number>
+    </property>
+    <property name="bottomMargin">
      <number>5</number>
     </property>
     <item>
@@ -38,28 +47,51 @@
       </widget>
       <widget class="QWidget" name="wdtReceivers" native="true">
        <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="lblReceivers"/>
-          </item>
-          <item>
-           <widget class="QToolButton" name="tlbReceivers">
-            <property name="toolTip">
-             <string>Fast choice</string>
-            </property>
-            <property name="popupMode">
-             <enum>QToolButton::InstantPopup</enum>
-            </property>
-            <property name="autoRaise">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QWidget" name="hboxReceiversW" native="true">
+          <layout class="QHBoxLayout" name="hboxReceivers">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="lblReceivers"/>
+           </item>
+           <item>
+            <widget class="QToolButton" name="tlbReceivers">
+             <property name="toolTip">
+              <string>Fast choice</string>
+             </property>
+             <property name="popupMode">
+              <enum>QToolButton::InstantPopup</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
          <widget class="QWidget" name="wdtReceiversTree" native="true">

--- a/src/plugins/messagewidgets/normalwindow.ui
+++ b/src/plugins/messagewidgets/normalwindow.ui
@@ -39,7 +39,10 @@
        <enum>Qt::Horizontal</enum>
       </property>
       <widget class="QWidget" name="layoutWidget">
-       <layout class="QVBoxLayout" name="verticalLayout">
+       <layout class="QVBoxLayout" name="vboxMessageBox">
+        <property name="rightMargin">
+         <number>2</number>
+        </property>
         <item>
          <widget class="SplitterWidget" name="spwMessageBox"/>
         </item>
@@ -48,7 +51,7 @@
       <widget class="QWidget" name="wdtReceivers" native="true">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="leftMargin">
-         <number>0</number>
+         <number>2</number>
         </property>
         <property name="topMargin">
          <number>0</number>

--- a/src/plugins/messagewidgets/receiverswidget.cpp
+++ b/src/plugins/messagewidgets/receiverswidget.cpp
@@ -461,6 +461,11 @@ void ReceiversWidget::clearSelection()
 			contactIt.value()->setCheckState(Qt::Unchecked);
 }
 
+QVBoxLayout *ReceiversWidget::getVBoxWidget()
+{
+	return ui.rwcVBox;
+}
+
 void ReceiversWidget::initialize()
 {
 }

--- a/src/plugins/messagewidgets/receiverswidget.h
+++ b/src/plugins/messagewidgets/receiverswidget.h
@@ -62,6 +62,8 @@ public:
 	virtual void setGroupSelection(const Jid &AStreamJid, const QString &AGroup, bool ASelected);
 	virtual void setAddressSelection(const Jid &AStreamJid, const Jid &AContactJid, bool ASelected);
 	virtual void clearSelection();
+	virtual QVBoxLayout *getVBoxWidget();
+
 signals:
 	void availStreamsChanged();
 	void addressSelectionChanged();

--- a/src/plugins/messagewidgets/receiverswidget.ui
+++ b/src/plugins/messagewidgets/receiverswidget.ui
@@ -10,41 +10,57 @@
     <height>329</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+  <layout class="QVBoxLayout" name="ReceiversWidgetClass_Layout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <widget class="SearchLineEdit" name="sleSearch">
-     <property name="placeholderText">
-      <string>Search Contacts</string>
+    <layout class="QVBoxLayout" name="rwcVBox">
+     <property name="spacing">
+      <number>11</number>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QTreeView" name="trvReceivers">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="indentation">
-      <number>10</number>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-     <property name="allColumnsShowFocus">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerVisible">
-      <bool>false</bool>
-     </attribute>
-    </widget>
+     <item>
+      <widget class="SearchLineEdit" name="sleSearch">
+       <property name="placeholderText">
+        <string>Search Contacts</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTreeView" name="trvReceivers">
+       <property name="contextMenuPolicy">
+        <enum>Qt::CustomContextMenu</enum>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="indentation">
+        <number>10</number>
+       </property>
+       <property name="rootIsDecorated">
+        <bool>false</bool>
+       </property>
+       <property name="allColumnsShowFocus">
+        <bool>true</bool>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
В окне создания сообщения UI какой-то поехавший. Поднял поле поиска наверх чтобы выглядело ровно.

https://i.imgur.com/Q9gvXDa.png

Почему в receiverswidget.ui  LayoutSpacing именно 11 не понятно.